### PR TITLE
fixes missing runtime libs

### DIFF
--- a/clarifai.gemspec
+++ b/clarifai.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.8.0"
-  spec.add_development_dependency "hashie", "2.0.5"
+  spec.add_runtime_dependency "hashie", "2.0.5"
   spec.add_runtime_dependency('faraday', ['>= 0.9', '< 0.10'])
   spec.add_runtime_dependency('faraday_middleware', ['>= 0.9', '< 0.10'])
 end

--- a/lib/clarifai/configuration.rb
+++ b/lib/clarifai/configuration.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../version', __FILE__)
+require 'faraday'
 
 module Clarifai
   # Defines constants and methods related to configuration

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'minitest/spec'
 require 'minitest/autorun'
 
-require 'faraday'
 require 'clarifai'
 
 def client_id


### PR DESCRIPTION
```
Gem Load Error is: uninitialized constant Clarifai::Configuration::Faraday
Backtrace for gem load error is:
<redacted>/clarifai-ruby/lib/clarifai/configuration.rb:32:in `<module:Configuration>'
```

```
RuntimeError: missing dependency for FaradayMiddleware::Mashify: cannot load such file -- hashie/mash
	from <redacted>/.rvm/gems/ruby-2.3.3@clarifai/gems/faraday-0.9.2/lib/faraday/middleware.rb:20:in `new'
```